### PR TITLE
Migrate CI/CD workflows to GitHub Container Registry and standard runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,8 +73,8 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         # Tag the existing image for GHCR with branch name
-        docker tag uptime-service-backend-test ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
-        docker tag uptime-service-backend-test ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
+        docker tag uptime-service-backend-test:latest ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
+        docker tag uptime-service-backend-test:latest ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
         # Push to GHCR
         docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
         docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     branches: 
       - main
 
+env:
+  REPO_OWNER_LOWER: ${{ github.repository_owner }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -53,22 +56,25 @@ jobs:
       run: echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
       id: extract_branch
 
+    - name: Repo owner lowercase
+      run: echo "REPO_OWNER_LOWER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
     - name: 🏷️ Tag and Push Docker Image (main branch)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
         # Tag the existing image for GHCR
-        docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:latest
-        docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
+        docker tag uptime-service-backend-test ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:latest
+        docker tag uptime-service-backend-test ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
         # Push to GHCR
-        docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:latest
-        docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
+        docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:latest
+        docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
 
     - name: 🏷️ Tag and Push Docker Image (pull request)
       if: github.event_name == 'pull_request'
       run: |
         # Tag the existing image for GHCR with branch name
-        docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
-        docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
+        docker tag uptime-service-backend-test ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
+        docker tag uptime-service-backend-test ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
         # Push to GHCR
-        docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
-        docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
+        docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
+        docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: 🛠️ Build Docker
       env:
-        TAG: ${{ env.IMAGE_NAME }}
+        TAG: latest
       run: nix-shell --run "make docker"
 
     - name: 🧪 Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   build:
-    runs-on: minafoundation-default-runners
+    runs-on: ubuntu-latest
 
     steps:
     - name: 📥 Checkout
-      uses: actions/checkout@v3    
+      uses: actions/checkout@v4
 
     - name: 📥 Update Git Submodules
       run: |
@@ -38,3 +38,21 @@ jobs:
 
     - name: 🧪 Test
       run: nix-shell --run "make test"
+
+    - name: 🔑 Log in to Container Registry
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: 🏷️ Tag and Push Docker Image
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        # Tag the existing image for GHCR
+        docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:latest
+        docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
+        # Push to GHCR
+        docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:latest
+        docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         git submodule update
 
     - name: 📦 Install Nix
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   REPO_OWNER_LOWER: ${{ github.repository_owner }}
+  IMAGE_NAME: uptime-service-backend-test
 
 jobs:
   build:
@@ -36,7 +37,7 @@ jobs:
 
     - name: 🛠️ Build Docker
       env:
-        TAG: uptime-service-backend-test
+        TAG: ${{ env.IMAGE_NAME }}
       run: nix-shell --run "make docker"
 
     - name: 🧪 Test
@@ -63,8 +64,8 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
         # Tag the existing image for GHCR
-        docker tag uptime-service-backend-test ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:latest
-        docker tag uptime-service-backend-test ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
+        docker tag ${{ env.IMAGE_NAME }} ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:latest
+        docker tag ${{ env.IMAGE_NAME }} ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
         # Push to GHCR
         docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:latest
         docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
@@ -73,8 +74,8 @@ jobs:
       if: github.event_name == 'pull_request'
       run: |
         # Tag the existing image for GHCR with branch name
-        docker tag uptime-service-backend-test:latest ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
-        docker tag uptime-service-backend-test:latest ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
+        docker tag ${{ env.IMAGE_NAME }}:latest ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
+        docker tag ${{ env.IMAGE_NAME }}:latest ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}
         # Push to GHCR
         docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
         docker push ghcr.io/${{ env.REPO_OWNER_LOWER }}/uptime-service-backend:${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     branches: 
       - main
-  workflow_dispatch:
 
 jobs:
   build:
@@ -41,7 +40,7 @@ jobs:
       run: nix-shell --run "make test"
 
     - name: 🔑 Log in to Container Registry
-      if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'pull_request'
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -49,9 +48,9 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: 🏷️ Extract branch name
-      if: github.event_name == 'workflow_dispatch'
+      if: github.event_name == 'pull_request'
       shell: bash
-      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      run: echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
       id: extract_branch
 
     - name: 🏷️ Tag and Push Docker Image (main branch)
@@ -64,8 +63,8 @@ jobs:
         docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:latest
         docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
 
-    - name: 🏷️ Tag and Push Docker Image (manual trigger)
-      if: github.event_name == 'workflow_dispatch'
+    - name: 🏷️ Tag and Push Docker Image (pull request)
+      if: github.event_name == 'pull_request'
       run: |
         # Tag the existing image for GHCR with branch name
         docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches: 
       - main
+  workflow_dispatch:
 
 jobs:
   build:
@@ -40,14 +41,20 @@ jobs:
       run: nix-shell --run "make test"
 
     - name: 🔑 Log in to Container Registry
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: 🏷️ Tag and Push Docker Image
+    - name: 🏷️ Extract branch name
+      if: github.event_name == 'workflow_dispatch'
+      shell: bash
+      run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+      id: extract_branch
+
+    - name: 🏷️ Tag and Push Docker Image (main branch)
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
         # Tag the existing image for GHCR
@@ -55,4 +62,14 @@ jobs:
         docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
         # Push to GHCR
         docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:latest
+        docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
+
+    - name: 🏷️ Tag and Push Docker Image (manual trigger)
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        # Tag the existing image for GHCR with branch name
+        docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
+        docker tag uptime-service-backend-test ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}
+        # Push to GHCR
+        docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ steps.extract_branch.outputs.branch }}
         docker push ghcr.io/${{ github.repository_owner }}/uptime-service-backend:${{ github.sha }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+env:
+  REPO_OWNER_LOWER: ${{ github.repository_owner }}
+  IMAGE_NAME: uptime-service-backend
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -36,7 +40,6 @@ jobs:
 
     - name: 🛠️ Build Docker
       env:
-        IMAGE_NAME: uptime-service-backend
         TAG: integration-test
       run: nix-shell --run "make docker"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   build:
-    runs-on: minafoundation-xlarge-runners
+    runs-on: ubuntu-latest
 
     steps:
     - name: 📥 Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 📥 Update Git Submodules
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
         git submodule update
 
     - name: 📦 Install Nix
-      uses: cachix/install-nix-action@v22
+      uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 
@@ -58,7 +58,7 @@ jobs:
         minimina node logs -n integration-test -i node-b -r > integration-test/logs/node-b.log
 
     - name: 📎 Upload logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: logs

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,7 +56,7 @@ jobs:
           tags: |
             type=ref,event=tag
       - name: 📦 Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: 🛠️ Build Uptime Service Backend Docker Image

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  DOCKER_TAG_PREFIX: ${{ github.event.inputs.docker_tag_prefix }}
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -33,7 +32,7 @@ jobs:
         run: |
           BRANCH_OR_TAG=$(basename ${{ github.ref }})
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            PREFIX=${{ env.DOCKER_TAG_PREFIX }}
+            PREFIX="${{ github.event.inputs.docker_tag_prefix }}"
             SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
             echo "TAG=$PREFIX-$BRANCH_OR_TAG-$SHORT_SHA" >> $GITHUB_ENV
           elif [ "${{ github.event_name }}" == "push" ] && [ -n "${{ github.event.ref }}" ]; then

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,8 @@ on:
         required: true
         type: string
 env:
-  ECR_REPOSITORY_URL: 673156464838.dkr.ecr.us-west-2.amazonaws.com
-  ECR_REPOSITORY_NAME: uptime-service-backend
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
   DOCKER_TAG_PREFIX: ${{ github.event.inputs.docker_tag_prefix }}
 
 # This allows a subsequently queued workflow run to interrupt previous runs
@@ -23,10 +23,10 @@ concurrency:
 jobs:
   build-docker-image:
     name: Build and Push Docker Image
-    runs-on: minafoundation-default-runners
+    runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: 🏷️ Generate Tag
@@ -42,25 +42,26 @@ jobs:
             echo "Invalid event. Exiting..."
             exit 1
           fi
-      - name: 🔑 ECR Login
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-      - name: 🔍 Check if Tag already exists
-        id: checktag
-        uses: tyriis/docker-image-tag-exists@v2.0.1
+      - name: 🔑 Log in to Container Registry
+        uses: docker/login-action@v3
         with:
-          registry: ${{ env.ECR_REPOSITORY_URL}}
-          repository: ${{ env.ECR_REPOSITORY_NAME }}
-          tag: ${{ env.TAG }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🏷️ Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
       - name: 📦 Install Nix
         uses: cachix/install-nix-action@v22
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: 🛠️ Build Uptime Service Backend Docker Image
-        if: steps.checktag.outputs.tag == 'not found'
         run: |
-          TAG=${{ env.TAG }}
+          IMAGE_NAME=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           nix-shell --run "make docker"
       - name: 🚚 Push Uptime Service Backend Docker Image
-        if: steps.checktag.outputs.tag == 'not found'
-        run: docker push ${{ env.ECR_REPOSITORY_URL}}/${{ env.ECR_REPOSITORY_NAME }}:${{ env.TAG }}
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$TAG

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Environment Setup
+
+This project requires Nix for consistent builds and development. All commands should be run inside the nix-shell:
+
+```bash
+$ nix-shell
+[nix-shell]$ # run commands here
+```
+
+## Common Commands
+
+### Building
+- `make` - Build the delegation backend binary
+- `make clean` - Remove build artifacts
+- `make docker` - Build Docker image (requires TAG environment variable)
+- `make tidy` - Run go mod tidy
+
+### Testing
+- `make test` - Run unit tests for delegation_backend
+- `make integration-test` - Run integration tests (requires UPTIME_SERVICE_SECRET)
+
+### Database Operations
+- `make db-migrate-up` - Run database migrations up
+- `make db-migrate-down` - Run database migrations down
+
+## Architecture Overview
+
+### Core Components
+
+**Delegation Backend Service** (`src/delegation_backend/`)
+- HTTP service listening on port 8080 that accepts block producer uptime submissions
+- Main entry point: `src/cmd/delegation_backend/main_bpu.go`
+- Configuration: `app_config.go` handles environment variables and JSON config files
+
+**ITN Uptime Analyzer** (`src/itn_uptime_analyzer/`)
+- Separate component for analyzing uptime data
+
+**Database Migration Tool** (`src/cmd/db_migration/`)
+- Handles Cassandra/AWS Keyspaces table creation and migrations
+
+### Key Modules
+
+**Storage Backends** - The service supports multiple storage backends simultaneously:
+- AWS S3 (`aws.go`)
+- AWS Keyspaces/Cassandra (`aws_keyspaces.go`) 
+- PostgreSQL (`postgres.go`)
+- Local filesystem
+
+**Authentication & Authorization**:
+- Whitelist management via Google Sheets integration (`sheets.go`)
+- Signature verification using Mina's reference signer (`signer.go`)
+- Rate limiting per public key (`time_heap.go`)
+
+**Data Processing**:
+- Block and submission validation (`data.go`, `submit.go`)
+- JSON payload unmarshaling and validation (`unmarshal_test.go`)
+
+### Configuration
+
+The service can be configured via:
+1. JSON configuration file (set `CONFIG_FILE` environment variable)
+2. Environment variables (see README.md for complete list)
+
+Key configuration areas:
+- Network settings (`CONFIG_NETWORK_NAME`)
+- Storage backend selection (AWS, PostgreSQL, filesystem)  
+- Whitelist management (Google Sheets integration)
+- Rate limiting (`REQUESTS_PER_PK_HOURLY`)
+
+### API Endpoints
+
+- `POST /v1/submit` - Primary endpoint for block producer submissions
+- `/health` - Health check endpoint
+- `/` - Basic service identifier
+
+### Build System
+
+The build process uses `scripts/build.sh` which:
+- Builds the C reference signer library
+- Compiles Go binaries for different components
+- Supports Docker image creation
+- Handles test execution
+
+### Testing Strategy
+
+- Unit tests: Focus on individual component logic
+- Integration tests: Full end-to-end testing with Docker containers
+- Test data: Located in `test/data/` with various payload samples
+
+## CI/CD Pipeline
+
+The repository uses GitHub Actions for continuous integration and deployment:
+
+### Workflows
+- **Build** (`.github/workflows/build.yml`) - Runs on PR and main branch pushes
+  - Builds binary and Docker image
+  - Runs unit tests
+  - Pushes to GitHub Container Registry (`ghcr.io`) on main branch
+- **Integration** (`.github/workflows/integration.yml`) - Full integration testing with Minimina
+- **Publish** (`.github/workflows/publish.yaml`) - Triggered by tags or manual dispatch
+  - Builds and publishes tagged releases to GitHub Container Registry
+
+### Container Registry
+- **Registry**: GitHub Container Registry (`ghcr.io`)  
+- **Image**: `ghcr.io/minafoundation/uptime-service-backend`
+- **Tags**: `latest` (main branch), commit SHA, and version tags
+
+**Note**: Recent changes migrated from AWS ECR to GitHub Container Registry and updated all workflows to use standard `ubuntu-latest` runners instead of custom MinaFoundation runners.
+
+## Development Notes
+
+- All Go code is in the `src/` directory
+- The project uses Go modules (`src/go.mod`)
+- External C dependencies are managed via the c-reference-signer submodule
+- Database schema migrations are in `database/migrations/`
+- Docker configuration in `dockerfiles/`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,7 +43,7 @@ case "$1" in
       exit 1
     fi
     # set image name to 673156464838.dkr.ecr.us-west-2.amazonaws.com/uptime-service-backend if IMAGE_NAME is not set
-    IMAGE_NAME=${IMAGE_NAME:-673156464838.dkr.ecr.us-west-2.amazonaws.com/uptime-service-backend}
+    IMAGE_NAME=${IMAGE_NAME:-uptime-service-backend}
     docker build -t "$IMAGE_NAME:$TAG" -f dockerfiles/Dockerfile-delegation-backend .
     ;;
   "")

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ in
 {
   devEnv = stdenv.mkDerivation {
     name = "dev";
-    buildInputs = [ stdenv go_1_22 glibc minaSigner ];
+    buildInputs = [ stdenv go glibc minaSigner ];
     shellHook = ''
       export LIB_MINA_SIGNER=${minaSigner}/lib/libmina_signer.so
       return


### PR DESCRIPTION
- Update all GitHub Actions workflows to use ubuntu-latest instead of custom MinaFoundation runners
- Migrate from AWS ECR to GitHub Container Registry (ghcr.io)
- Configure automatic image publishing to ghcr.io/minafoundation/uptime-service-backend
- Add container registry push on main branch builds
- Fix TAG environment variable scope issue in publish workflow
- Update CLAUDE.md with CI/CD pipeline documentation